### PR TITLE
Process multiple files

### DIFF
--- a/checksum/src/main/scala/uk/gov/nationalarchives/tdr/checksum/RequestHandler.scala
+++ b/checksum/src/main/scala/uk/gov/nationalarchives/tdr/checksum/RequestHandler.scala
@@ -27,7 +27,6 @@ class RequestHandler extends RequestStreamHandler {
       val checksum = checksumRequest.checksum
       val fileId = checksumRequest.file.split("/")(1)
       val query = s"""mutation Bob {updateServerSideFileChecksum(checksum: "$checksum", id: "$fileId")}"""
-      println(query)
       val apiClient = new ApiClient()
       val body = apiClient.sendQueryToApi(query)
       val apiResponse: Either[circe.Error, ChecksumApiResponse] = decode[ChecksumApiResponse](body)
@@ -35,7 +34,6 @@ class RequestHandler extends RequestStreamHandler {
         case Right(response) => response.data.updateServerSideFileChecksum
         case Left(err) => print(err); false
       }
-      println(success)
       outputStream.write(success.toString.getBytes())
     }
   }

--- a/checksum/src/main/scala/uk/gov/nationalarchives/tdr/checksum/RequestHandler.scala
+++ b/checksum/src/main/scala/uk/gov/nationalarchives/tdr/checksum/RequestHandler.scala
@@ -22,12 +22,12 @@ class RequestHandler extends RequestStreamHandler {
 
     for {
       inputRequest <- decode[Input](inputString)
-      snsInputObj <- decode[SnsInput](inputRequest.Records.head.Sns.Message)
+      checksumRequest <- decode[ChecksumRequest](inputRequest.Records.head.Sns.Message)
     } yield {
-      val checksumRequest = snsInputObj.Input
       val checksum = checksumRequest.checksum
       val fileId = checksumRequest.file.split("/")(1)
       val query = s"""mutation Bob {updateServerSideFileChecksum(checksum: "$checksum", id: "$fileId")}"""
+      println(query)
       val apiClient = new ApiClient()
       val body = apiClient.sendQueryToApi(query)
       val apiResponse: Either[circe.Error, ChecksumApiResponse] = decode[ChecksumApiResponse](body)
@@ -35,6 +35,7 @@ class RequestHandler extends RequestStreamHandler {
         case Right(response) => response.data.updateServerSideFileChecksum
         case Left(err) => print(err); false
       }
+      println(success)
       outputStream.write(success.toString.getBytes())
     }
   }

--- a/fileformat/src/main/scala/uk/gov/nationalarchives/tdr/fileformat/RequestHandler.scala
+++ b/fileformat/src/main/scala/uk/gov/nationalarchives/tdr/fileformat/RequestHandler.scala
@@ -16,7 +16,6 @@ class RequestHandler extends RequestStreamHandler {
     case class Matches(ns: String, id: String, format: String, version: String, mime: String, basis: String, warning: String)
     case class Files(filename: String, filesize: Double, modified: String, errors: String, matches: List[Matches])
     case class FileFormat(siegfried: String, scandate: String, signature: String, created: String, identifiers: List[Identifiers], files: List[Files])
-    case class SnsInput(Input: FileFormat)
 
     val inputString = Source.fromInputStream(inputStream, "UTF-8").mkString
 
@@ -24,9 +23,8 @@ class RequestHandler extends RequestStreamHandler {
 
     for {
       inputRequest <- decode[Input](inputString)
-      snsInputObj <- decode[SnsInput](inputRequest.Records.head.Sns.Message)
+      fileFormatRequest <- decode[FileFormat](inputRequest.Records.head.Sns.Message)
     } yield {
-      val fileFormatRequest =  snsInputObj.Input
       val file = fileFormatRequest.files.head
       val success = file.matches.forall(fileMatch => {
         val query = s"""mutation {updateFileFormat(pronomId: "${fileMatch.id}", id: "${file.filename}")}"""

--- a/virus/src/main/scala/uk/gov/nationalarchives/tdr/virus/RequestHandler.scala
+++ b/virus/src/main/scala/uk/gov/nationalarchives/tdr/virus/RequestHandler.scala
@@ -13,16 +13,14 @@ import scala.io.Source
 class RequestHandler extends RequestStreamHandler {
   override def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
     case class VirusCheckRequest(status: String, filename: String)
-    case class SnsInput(Input: VirusCheckRequest)
     val inputString = Source.fromInputStream(inputStream, "UTF-8").mkString
 
     print(inputString)
 
     for {
       inputRequest <- decode[Input](inputString)
-      snsInputObj <- decode[SnsInput](inputRequest.Records.head.Sns.Message)
+      virusCheckRequest <- decode[VirusCheckRequest](inputRequest.Records.head.Sns.Message)
     } yield {
-      val virusCheckRequest = snsInputObj.Input
       val status = virusCheckRequest.status
       val fileId = virusCheckRequest.filename.split("/")(1)
       val query = s"""mutation {updateVirusCheck(status: "$status", id: "$fileId")}"""


### PR DESCRIPTION
Because we're not getting the message into the lambda via the step function any more, it's not wrapped in the step  function input json so we can get rid of it.